### PR TITLE
Fix type incompatibility of the argument in parse_str()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -102,8 +102,7 @@ function auth_mumie_output_fragment_new_mumieserver_form($args) {
 
     $formdata = [];
     if (!empty($args->jsonformdata)) {
-        $serialiseddata = json_decode($args->jsonformdata);
-        parse_str($serialiseddata, $formdata);
+        $formdata = json_decode($args->jsonformdata, true);
     }
     $mumieserver = new stdClass();
 


### PR DESCRIPTION
Hello,

after updating to PHP 8.0, I got this error, when I open the moodle site admin:

![error_parse_str](https://user-images.githubusercontent.com/52955347/183076246-294af182-675a-46fd-b1b5-ef48668df587.png)

The exception occurs because the first argument in parse_str needs a string, but what we get from json_decode($args->jsonformdata) is an object (as long as its second argument is not true: [json_decode docu](https://www.php.net/manual/en/function.json-decode.php) ).

So I've changed the code, so then the json_decode give us the correct data type (in case array for the $formdata).

Please have a look of my changes and let me know if it is ok or you do have any other solution for the problem.

Thx and cheers :)
Nisa
