### PR TITLE
Fix Deprecation Warnings for Php 8.1

### DIFF
--- a/classes/mumie_course.php
+++ b/classes/mumie_course.php
@@ -194,7 +194,7 @@ class mumie_course implements \JsonSerializable {
      * Necessary to encode this object as json.
      * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $vars = get_object_vars($this);
 
         return $vars;

--- a/classes/mumie_problem.php
+++ b/classes/mumie_problem.php
@@ -139,7 +139,7 @@ class mumie_problem implements \JsonSerializable {
      * Necessary to encode this object as json.
      * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $vars = get_object_vars($this);
         return $vars;
     }

--- a/classes/mumie_server.php
+++ b/classes/mumie_server.php
@@ -303,7 +303,7 @@ class mumie_server implements \JsonSerializable {
      * Necessary to encode this object as json.
      * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $vars = get_object_vars($this);
 
         return $vars;

--- a/classes/mumie_tag.php
+++ b/classes/mumie_tag.php
@@ -62,7 +62,7 @@ class mumie_tag implements \JsonSerializable {
      * Necessary to encode this object as json.
      * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $vars = get_object_vars($this);
 
         return $vars;


### PR DESCRIPTION
![grafik](https://github.com/integral-learning/moodle-auth_mumie/assets/166120315/4876b2bc-ffaa-4ecc-bbdd-b32fbd3e0492)

when using php 8.1 deprecation warnings are displayed in debug mode.

With this small fix there are no more warnings.